### PR TITLE
Add option to override sysctl setting name

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ These variables are set in `defaults/main.yml`:
 ---
 # defaults file for ansible-role-haveged
 
+# Set name of the sysctl write_wakeup_threshold setting.
+haveged_write_wakeup_threshold_setting_name: write_wakeup_threshold
+
 # Set write_wakeup_threshold of daemon interface to nnn bits.
 haveged_write_wakeup_threshold: 1024
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 # defaults file for ansible-role-haveged
 
+# Set name of the sysctl write_wakeup_threshold setting.
+haveged_write_wakeup_threshold_setting_name: write_wakeup_threshold
+
 # Set write_wakeup_threshold of daemon interface to nnn bits.
 haveged_write_wakeup_threshold: 1024

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: set write_wakeup_threshold
   sysctl:
-    name: write_wakeup_threshold
+    name: "{{ haveged_write_wakeup_threshold_setting_name }}"
     value: "{{ haveged_write_wakeup_threshold }}"
   when:
     - ansible_connection != "docker"


### PR DESCRIPTION
**Describe the change**
I'm using this role on a CIS-hardened RHEL 8 host. There, the sysctl setting name differs from the default: `kernel.random.write_wakeup_threshold`. So, the role fails with the following error:
```
TASK [robertdebock.haveged : set write_wakeup_threshold] *************************************************************************************************************************************************
Friday 25 September 2020  08:56:03 +0000 (0:00:03.379)       0:00:26.679 ******
[WARNING]: The value 1024 (type int) in a string field was converted to '1024' (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.
fatal: [myhost]: FAILED! => {"changed": false, "msg": "Failed to reload sysctl: fs.suid_dumpable = 0\nkernel.randomize_va_space = 2\nnet.ipv4.ip_forward = 0\nnet.ipv4.conf.all.send_redirects = 0\nnet.ipv4.conf.default.send_redirects = 0\nnet.ipv4.conf.all.accept_source_route = 0\nnet.ipv4.conf.default.accept_source_route = 0\nnet.ipv6.conf.all.accept_source_route = 0\nnet.ipv6.conf.default.accept_source_route = 0\nnet.ipv4.conf.all.accept_redirects = 0\nnet.ipv4.conf.default.accept_redirects = 0\nnet.ipv4.conf.all.secure_redirects = 0\nnet.ipv4.conf.default.secure_redirects = 0\nnet.ipv4.conf.all.log_martians = 1\nnet.ipv4.conf.default.log_martians = 1\nnet.ipv4.icmp_echo_ignore_broadcasts = 1\nnet.ipv4.icmp_ignore_bogus_error_responses = 1\nnet.ipv4.conf.all.rp_filter = 1\nnet.ipv4.conf.default.rp_filter = 1\nnet.ipv4.tcp_syncookies = 1\nnet.ipv6.conf.all.accept_ra = 0\nnet.ipv6.conf.default.accept_ra = 0\nnet.ipv6.conf.all.accept_redirects = 0\nnet.ipv6.conf.default.accept_redirects = 0\nvm.swappiness = 60\nsysctl: cannot stat /proc/sys/write_wakeup_threshold: No such file or directory\n"}
```

This PR makes the name of the setting overridable. The default still remains the same.

**Testing**
I have tested this on my RHEL 8 hosts.
