### PR TITLE
sysctl task expects a string

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: set write_wakeup_threshold
   sysctl:
     name: kernel.random.write_wakeup_threshold
-    value: "{{ haveged_write_wakeup_threshold }}"
+    value: "{{ haveged_write_wakeup_threshold | string }}"
     state: present
   when:
     - ansible_connection != "docker"


### PR DESCRIPTION
another fix for the recent number assertion change. running ansible without this fix produces the following warning:

```
TASK [haveged : set write_wakeup_threshold] **************************************************************************************************************************************************
[WARNING]: The value "1024" (type int) was converted to "'1024'" (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.
```