### PR TITLE
FIx systemd warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
   ansible.builtin.template:
     src: custom.conf.j2
     dest: /etc/systemd/system/haveged.service.d/custom.conf
-    mode: "0640"
+    mode: "0644"
   notify:
     - daemon reload
   when:


### PR DESCRIPTION
systemd[1]: Configuration file /etc/systemd/system/haveged.service.d/custom.conf is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.
